### PR TITLE
Don't fail if resource provider can not be deleted

### DIFF
--- a/templates/drainpod/bin/scaledownpost.sh
+++ b/templates/drainpod/bin/scaledownpost.sh
@@ -46,7 +46,8 @@ done
 PLACEMENT_PROVIDER_ID=$(openstack resource provider list -f value \
                           -c uuid --name ${SCALE_DOWN_NODE_NAME})
 while [ -n "${PLACEMENT_PROVIDER_ID}" ]; do
-  openstack resource provider delete ${PLACEMENT_PROVIDER_ID}
+  echo "Deleting resource provider ${PLACEMENT_PROVIDER_ID}"
+  openstack resource provider delete ${PLACEMENT_PROVIDER_ID} || true
   sleep 5
   PLACEMENT_PROVIDER_ID=$(openstack resource provider list -f value \
                             -c uuid --name ${SCALE_DOWN_NODE_NAME})


### PR DESCRIPTION
If the resource provider has orphaned allocations the delete action
fails with:

$ openstack resource provider delete 5361d775-7f4a-4f5d-aacc-03f8eeea881b
Unable to delete resource provider 5361d775-7f4a-4f5d-aacc-03f8eeea881b: Resource provider has allocations. (HTTP 409)

For now we don't fail here and just wait for manial cleanup of the
allocations.