### PR TITLE
Move compute-node-operator to openstack namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Create custom resource for a compute node which specifies the needed information
     kind: ComputeNodeOpenStack
     metadata:
       name: example-computenodeopenstack
-      namespace: openshift-machine-api
+      namespace: openstack
     spec:
       # Add fields here
       roleName: worker-osp
@@ -122,13 +122,13 @@ Apply the CR:
 
     oc apply -f deploy/crds/compute-node.openstack.org_v1alpha1_computenodeopenstack_cr.yaml
     
-    oc get pods -n openshift-machine-api
+    oc get pods -n openstack
     NAME                                   READY   STATUS    RESTARTS   AGE
     compute-node-operator-ffd64796-vshg6   1/1     Running   0          119s
 
 Get the generated machineconfig and machinesets
 
-    oc get machineset  -n openshift-machine-api
+    oc get machineset -n openshift-machine-api
     oc get machineconfigpool
     oc get machineconfig
 
@@ -139,7 +139,7 @@ Get the generated machineconfig and machinesets
 
 Edit the computenodeopenstack CR:
 
-    oc -n openshift-machine-api edit computenodeopenstacks.compute-node.openstack.org example-computenodeopenstack
+    oc -n openstack edit computenodeopenstacks.compute-node.openstack.org example-computenodeopenstack
     # Modify the number of workers and exit
 
     oc get machineset -n openshift-machine-api
@@ -153,7 +153,7 @@ There are different ways to remove a compute worker node from the OpenStack envi
 
 Edit the computenodeopenstack CR and lower the workers number, save and exit:
 
-    oc -n openshift-machine-api edit computenodeopenstacks.compute-node.openstack.org example-computenodeopenstack
+    oc -n openstack edit computenodeopenstacks.compute-node.openstack.org example-computenodeopenstack
 
 OCP will choose a compute worker node to be removed. Per the `deletePolicy` of the compute worker machineset is set to `Newest`, therefore the newest compute node is expected to be removed. Depending on the status of the instances and `drain` configuration, manual migration/cleanup of the instances is required.
 
@@ -165,7 +165,7 @@ The following command will show which compute worker node got disabled to be rem
 
 Edit the computenodeopenstack CR, lower the workers number and add a `nodesToDelete` section in the spec with the details of the worker node which should be removed:
 
-    oc -n openshift-machine-api edit computenodeopenstacks.compute-node.openstack.org example-computenodeopenstack
+    oc -n openstack edit computenodeopenstacks.compute-node.openstack.org example-computenodeopenstack
 
 Modify the number of `workers` and add the `nodesToDelete` section to the spec:
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -107,6 +107,7 @@ func main() {
 	if strings.Contains(namespace, ",") {
 		options.Namespace = ""
 		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(namespace, ","))
+		log.Info(fmt.Sprintf("Namespaces added to the cache: %s", namespace))
 	}
 
 	// Create a new manager to provide shared dependencies and start components

--- a/deploy/crds/compute-node.openstack.org_computenodeopenstacks_crd.yaml
+++ b/deploy/crds/compute-node.openstack.org_computenodeopenstacks_crd.yaml
@@ -145,9 +145,6 @@ spec:
               description: openstackclient configmap which holds information to connect
                 to OpenStack API
               type: string
-            openStackNamespace:
-              description: Namespace OpenStack resources are created, default openstack
-              type: string
             roleName:
               description: Name of the worker role created for OSP computes
               type: string

--- a/deploy/crds/compute-node.openstack.org_v1alpha1_computenodeopenstack_cr.yaml
+++ b/deploy/crds/compute-node.openstack.org_v1alpha1_computenodeopenstack_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: compute-node.openstack.org/v1alpha1
 kind: ComputeNodeOpenStack
 metadata:
   name: example-computenodeopenstack
-  namespace: openshift-machine-api
+  namespace: openstack
 spec:
   # Add fields here
   roleName: worker-osp
@@ -36,4 +36,3 @@ spec:
     enabled: false
   openStackClientAdminSecret: openstackclient-admin
   openStackClientConfigMap: openstackclient
-  openStackNamespace: openstack

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: compute-node-operator
-  namespace: openshift-machine-api
+  namespace: openstack
 spec:
   replicas: 1
   selector:
@@ -23,9 +23,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: "openstack,openshift-machine-api"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -118,11 +118,6 @@ rules:
   - update
 - apiGroups:
   - machine.openshift.io
-  resources:
-    - '*'
-  verbs:
-    - '*'
-- apiGroups:
   - machineconfiguration.openshift.io
   resources:
     - '*'
@@ -140,3 +135,11 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - hostnetwork
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: compute-node-operator
-  namespace: openshift-machine-api
+  namespace: openstack
 roleRef:
   kind: ClusterRole
   name: compute-node-operator

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: compute-node-operator
-  namespace: openshift-machine-api
+  namespace: openstack

--- a/pkg/apis/computenode/v1alpha1/computenodeopenstack_types.go
+++ b/pkg/apis/computenode/v1alpha1/computenodeopenstack_types.go
@@ -24,8 +24,6 @@ type ComputeNodeOpenStackSpec struct {
 	InfraDaemonSets []InfraDaemonSet `json:"infraDaemonSets,omitempty"`
 	// Nodes to delete upon scale down
 	NodesToDelete []NodeToDelete `json:"nodesToDelete,omitempty"`
-	// Namespace OpenStack resources are created, default openstack
-	OpenStackNamespace string `json:"openStackNamespace,omitempty"`
 	// openstackclient configmap which holds information to connect to OpenStack API
 	OpenStackClientConfigMap string `json:"openStackClientConfigMap"`
 	// user secrets used to connect to OpenStack API via openstackclient

--- a/tools/helper/helper.go
+++ b/tools/helper/helper.go
@@ -15,6 +15,8 @@ limitations under the License.
 package helper
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -91,15 +93,11 @@ func CreateOperatorContainer(name, image, verbosity string, pullPolicy corev1.Pu
 }
 
 // CreateOperatorEnvVar creates the operator container environment variables based on the passed in parameters
-func CreateOperatorEnvVar(repo, deployClusterResources, operatorImage, pullPolicy string) *[]corev1.EnvVar {
+func CreateOperatorEnvVar(repo, deployClusterResources, operatorImage, pullPolicy string, namespace string) *[]corev1.EnvVar {
 	return &[]corev1.EnvVar{
 		{
-			Name: "WATCH_NAMESPACE",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.namespace",
-				},
-			},
+			Name:  "WATCH_NAMESPACE",
+			Value: fmt.Sprintf(namespace + ",openshift-machine-api"),
 		},
 		{
 			Name: "POD_NAME",


### PR DESCRIPTION
Previously the compute-node-operator was running on the
openshift-machine-api namespace. All other OSP related operators
are in the openstack namespace. Therefore the compute-node-operator
should also run in the openstack namespace.