### PR TITLE
Set hostSelector in machineset to map hosts to it

### DIFF
--- a/bindata/worker-osp/007-worker-osp-machineset.yaml
+++ b/bindata/worker-osp/007-worker-osp-machineset.yaml
@@ -24,7 +24,9 @@ spec:
     spec:
       providerSpec:
         value:
-          hostSelector: {}
+          hostSelector:
+            matchLabels:
+              ospRole: {{ .WorkerOspRole }}
           image:
             checksum: {{ .RhcosImageUrl }}.md5sum
             url: {{ .RhcosImageUrl }}


### PR DESCRIPTION
Right now any free node gets picked from the pool to scale a
machineset. We usually have a baremetal node -> machineset
mapping. Therefore this change sets the 'ospRole: <.WorkerOspRole>'
as hostSelector in the machineset. Afterwards the baremetal nodes
can be labeled to one of the roles in the environment.