### PR TITLE
Remove cross namespace owner ref

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	k8s.io/api v0.17.8
 	k8s.io/apimachinery v0.17.8
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/klog v1.0.0
 	sigs.k8s.io/controller-runtime v0.5.8
 )
 

--- a/pkg/computenodeopenstack/machineset.go
+++ b/pkg/computenodeopenstack/machineset.go
@@ -1,0 +1,23 @@
+package computenodeopenstack
+
+import (
+	"context"
+
+	"github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	computenodev1alpha1 "github.com/openstack-k8s-operators/compute-node-operator/pkg/apis/computenode/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetMachineSetsWithLabel - Returns list of machinesets labeled with labelSelector
+func GetMachineSetsWithLabel(c client.Client, instance *computenodev1alpha1.ComputeNodeOpenStack, labelSelector map[string]string, namespace string) (*v1beta1.MachineSetList, error) {
+	machineSets := &v1beta1.MachineSetList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels(labelSelector),
+	}
+	if err := c.List(context.Background(), machineSets, listOpts...); err != nil {
+		return nil, err
+	}
+
+	return machineSets, nil
+}


### PR DESCRIPTION
Owner refs are not allowed to be cross namespaces. The garbage
collector would not find the owner inside the namespace and
clean up resources, like we have seen with machinesets or infra
daemonsets.
    
This change removes the owner ref on non openstack objects. It
keeps the owner ref on the openstack namespace and not namespaced
objects, like machineconfig. It adds labels to all objects it
creates with uid, namespace and name of the owning CR, like:
    
computenodeopenstacks.compute-node.openstack.org/uid: f4a99d2f-ad72-4f17-a0af-0e1d7887ccec
computenodeopenstacks.compute-node.openstack.org/namespace: openstack
computenodeopenstacks.compute-node.openstack.org/name: default
    
The namespace/name is used when watching the machinesets to reconcile
for the owning CR.
When the CR gets deleted the objects get removed using the finalizer.