### PR TITLE
Manage selinux using CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Create custom resource for a compute node which specifies the needed information
       k8sServiceIp: 172.30.0.1
       apiIntIp: 192.168.111.5
       workers: 1
+      selinuxDisabled: true
       corePinning: "4-7"   # Optional
       infraDaemonSets:     # Optional
       - name: multus

--- a/bindata/worker-osp/005-worker-osp-selinuxoff.yaml
+++ b/bindata/worker-osp/005-worker-osp-selinuxoff.yaml
@@ -1,3 +1,4 @@
+{{if .SelinuxDisabled}}
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
@@ -9,4 +10,5 @@ spec:
     ignition:
       version: 2.2.0
   kernelArguments:
-    - selinux=0
+    - selinux={{ .SelinuxDisabled }}
+{{- end}}

--- a/deploy/crds/compute-node.openstack.org_computenodeopenstacks_crd.yaml
+++ b/deploy/crds/compute-node.openstack.org_computenodeopenstacks_crd.yaml
@@ -148,6 +148,9 @@ spec:
             roleName:
               description: Name of the worker role created for OSP computes
               type: string
+            selinuxDisabled:
+              description: Manage selinux - Defaults to false
+              type: boolean
             workers:
               description: Number of workers
               format: int32

--- a/deploy/crds/compute-node.openstack.org_v1alpha1_computenodeopenstack_cr.yaml
+++ b/deploy/crds/compute-node.openstack.org_v1alpha1_computenodeopenstack_cr.yaml
@@ -11,6 +11,7 @@ spec:
   k8sServiceIP: 172.30.0.1
   apiIntIP: 192.168.111.5
   workers: 0
+  selinuxDisabled: true
   compute:
     novaComputeCPUDedicatedSet: "4-7"
     novaComputeCPUSharedSet: "0-3"

--- a/pkg/apis/computenode/v1alpha1/computenodeopenstack_types.go
+++ b/pkg/apis/computenode/v1alpha1/computenodeopenstack_types.go
@@ -34,6 +34,8 @@ type ComputeNodeOpenStackSpec struct {
 	Compute NovaCompute `json:"compute,omitempty"`
 	// Network/Neutron configuration
 	Network NeutronNetwork `json:"network,omitempty"`
+	// Manage selinux - Defaults to false
+	SelinuxDisabled bool `json:"selinuxDisabled,omitempty"`
 }
 
 // InfraDaemonSet defines the daemon set required
@@ -69,7 +71,7 @@ type NovaCompute struct {
 
 // NeutronNetwork defines neutron configuration parameters
 type NeutronNetwork struct {
-	Nic				 string `json:"nic"`
+	Nic              string      `json:"nic"`
 	BridgeMappings   string      `json:"bridgeMappings,omitempty"`
 	MechanishDrivers string      `json:"mechanismDrivers,omitempty"`
 	ServicePlugings  string      `json:"servicePlugins,omitempty"`

--- a/pkg/controller/computenodeopenstack/computenodeopenstack_controller.go
+++ b/pkg/controller/computenodeopenstack/computenodeopenstack_controller.go
@@ -387,6 +387,14 @@ func getRenderData(ctx context.Context, client client.Client, instance *computen
 		data.Data["Nic"] = instance.Spec.Network.Nic
 	}
 
+	// disable selinux if set
+	// TODO use performance tuning operator for this when implemented for cpu pinning, ...
+	data.Data["SelinuxDisabled"] = false
+	if instance.Spec.SelinuxDisabled {
+		data.Data["SelinuxDisabled"] = true
+		log.Info(fmt.Sprintf("SELINUX will be DISABLED for worker role: %s!!", data.Data["WorkerOspRole"]))
+	}
+
 	// get it from openshift-machine-api secrets (assumes worker-user-data)
 	userData := &corev1.Secret{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: "worker-user-data", Namespace: "openshift-machine-api"}, userData)


### PR DESCRIPTION
So far selinux was disable per default. Make this a parameter
to be managable. We use a machineconfig for this to set a kernel
parameter when SelinuxDisabled: true is set in the CR.

When performance tuning operator is integrated for cpu pinnig and
other kernel parameters, lets switch to that as well. Therefore
no handling when flipping from true to false is there which means
the machineconfig is still there when we flip from selinux
disabled to enabled.