### PR TITLE
Add option to have either dedicated or shared compute workers

### DIFF
--- a/bindata/worker-osp/007-worker-osp-machineset.yaml
+++ b/bindata/worker-osp/007-worker-osp-machineset.yaml
@@ -27,10 +27,12 @@ spec:
           node-role.kubernetes.io/{{ .WorkerOspRole }}: ""
           network.operator.openshift.io/external-openvswitch: ""
           #beta.kubernetes.io/os: osp # only needed if we want to kick out openshift-sdn
+{{if .Dedicated}}
       taints:
       - effect: NoSchedule
         key: dedicated
         value: {{ .WorkerOspRole }}
+{{- end}}
       providerSpec:
         value:
           hostSelector:

--- a/deploy/crds/compute-node.openstack.org_computenodeopenstacks_crd.yaml
+++ b/deploy/crds/compute-node.openstack.org_computenodeopenstacks_crd.yaml
@@ -64,6 +64,10 @@ spec:
             corePinning:
               description: Cores Pinning
               type: string
+            dedicated:
+              description: Make or not the Node dedicated to OSP workloads (does not
+                account for infra pods)
+              type: boolean
             drain:
               description: Node draining configuration options
               properties:

--- a/deploy/crds/compute-node.openstack.org_v1alpha1_computenodeopenstack_cr.yaml
+++ b/deploy/crds/compute-node.openstack.org_v1alpha1_computenodeopenstack_cr.yaml
@@ -11,6 +11,7 @@ spec:
   k8sServiceIP: 172.30.0.1
   apiIntIP: 192.168.111.5
   workers: 0
+  dedicated: false
   selinuxDisabled: true
   compute:
     novaComputeCPUDedicatedSet: "4-7"

--- a/pkg/apis/computenode/v1alpha1/computenodeopenstack_types.go
+++ b/pkg/apis/computenode/v1alpha1/computenodeopenstack_types.go
@@ -20,6 +20,8 @@ type ComputeNodeOpenStackSpec struct {
 	Workers int32 `json:"workers,omitempty"`
 	// Cores Pinning
 	CorePinning string `json:"corePinning,omitempty"`
+	// Make or not the Node dedicated to OSP workloads (does not account for infra pods)
+	Dedicated bool `json:"dedicated,omitempty"`
 	// Infra DaemonSets needed
 	InfraDaemonSets []InfraDaemonSet `json:"infraDaemonSets,omitempty"`
 	// Nodes to delete upon scale down

--- a/pkg/controller/computenodeopenstack/computenodeopenstack_controller.go
+++ b/pkg/controller/computenodeopenstack/computenodeopenstack_controller.go
@@ -358,6 +358,10 @@ func getRenderData(ctx context.Context, client client.Client, instance *computen
 	data.Data["K8sServiceIP"] = instance.Spec.K8sServiceIP
 	data.Data["APIIntIP"] = instance.Spec.APIIntIP
 	data.Data["Workers"] = instance.Spec.Workers
+	data.Data["Dedicated"] = false
+	if instance.Spec.Dedicated {
+		data.Data["Dedicated"] = instance.Spec.Dedicated
+	}
 
 	data.Data["Isolcpus"] = false
 	data.Data["SshdPort"] = 2022
@@ -382,7 +386,7 @@ func getRenderData(ctx context.Context, client client.Client, instance *computen
 		data.Data["OspSecrets"] = instance.Spec.Compute.OspSecrets
 	}
 
-	data.Data["Nic"] = "enp6s0"
+	data.Data["Nic"] = "enp2s0"
 	if instance.Spec.Network.Nic != "" {
 		data.Data["Nic"] = instance.Spec.Network.Nic
 	}


### PR DESCRIPTION
The new option on the CRD is named "dedicated". By default is TRUE
if not specified. If set to false, the taint is not set on the
machineset and therefore not added to the generated worker nodes
either. That will allow any OpenShift pod to run on OpenStack worker
nodes. By contrast, if the node is dedicated, that means the taint is
added and therefore only infra pods can be executed there, like the
ones needed for monitorization, OpenShift SDN, machine configuration,
etc.