### PR TITLE
Change nova-operator CR verstion to v1beta1

### DIFF
--- a/bindata/nova/001-virtlogd.yaml
+++ b/bindata/nova/001-virtlogd.yaml
@@ -1,4 +1,4 @@
-apiVersion: nova.openstack.org/v1
+apiVersion: nova.openstack.org/v1beta1
 kind: Virtlogd
 metadata:
   name: virtlogd-{{ .WorkerOspRole }}

--- a/bindata/nova/002-libvirtd.yaml
+++ b/bindata/nova/002-libvirtd.yaml
@@ -1,4 +1,4 @@
-apiVersion: nova.openstack.org/v1
+apiVersion: nova.openstack.org/v1beta1
 kind: Libvirtd
 metadata:
   name: libvirtd-{{ .WorkerOspRole }}

--- a/bindata/nova/003-iscsid.yaml
+++ b/bindata/nova/003-iscsid.yaml
@@ -1,4 +1,4 @@
-apiVersion: nova.openstack.org/v1
+apiVersion: nova.openstack.org/v1beta1
 kind: Iscsid
 metadata:
   name: iscsid-{{ .WorkerOspRole }}

--- a/bindata/nova/004-migration-target.yaml
+++ b/bindata/nova/004-migration-target.yaml
@@ -1,4 +1,4 @@
-apiVersion: nova.openstack.org/v1
+apiVersion: nova.openstack.org/v1beta1
 kind: NovaMigrationTarget
 metadata:
   name: nova-migration-target-{{ .WorkerOspRole }}

--- a/bindata/nova/005-compute.yaml
+++ b/bindata/nova/005-compute.yaml
@@ -1,4 +1,4 @@
-apiVersion: nova.openstack.org/v1
+apiVersion: nova.openstack.org/v1beta1
 kind: NovaCompute
 metadata:
   name: nova-compute-{{ .WorkerOspRole }}


### PR DESCRIPTION
[1] upgrades the sdk version of nova-operator to 1.0 and changes
the CRD verstion to v1beta1 as this is the status for them. Therefore
we need to change it here as well.

[1] https://github.com/openstack-k8s-operators/nova-operator/pull/44