### PR TITLE
Change neutron-operator CR verstion to v1beta1

### DIFF
--- a/bindata/neutron/001-ovs-node-osp.yaml
+++ b/bindata/neutron/001-ovs-node-osp.yaml
@@ -1,4 +1,4 @@
-apiVersion: neutron.openstack.org/v1
+apiVersion: neutron.openstack.org/v1beta1
 kind: OVSNodeOsp
 metadata:
   name: ovs-node-osp-{{ .WorkerOspRole }}

--- a/bindata/neutron/002-ovn-controller.yaml
+++ b/bindata/neutron/002-ovn-controller.yaml
@@ -1,5 +1,5 @@
 
-apiVersion: neutron.openstack.org/v1
+apiVersion: neutron.openstack.org/v1beta1
 kind: OVNController
 metadata:
   name: ovncontroller-{{ .WorkerOspRole }}


### PR DESCRIPTION
Upgrades the sdk version of neutron-operator changes
the CRD version to v1beta1 as this is the status for them. Therefore
we need to change it here as well. Also ovs is not functional anymore
and it is removed now