### PR TITLE
Changes due to nova-operator rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,37 +32,32 @@ control-plane operator.
 Create `openstackclient` ConfigMap file (e.g. `openstackclient-cm.yaml`)
 
     apiVersion: v1
+    data:
+      OS_CLOUD: default
+      clouds.yaml: |
+        clouds:
+          default:
+            auth:
+              auth_url: http://keystone-openstack.apps.ostest.test.metalkube.org
+              project_name: admin
+              username: admin
+              user_domain_name: Default
+              project_domain_name: Default
+            region_name: regionOne
     kind: ConfigMap
     metadata:
-      name: openstackclient
+      name: openstack-config
       namespace: openstack
-    data:
-      NOVA_VERSION: "1.1"
-      COMPUTE_API_VERSION: "1.1"
-      OS_USER_DOMAIN_NAME: "Default"
-      OS_PROJECT_DOMAIN_NAME: "Default"
-      OS_NO_CACHE: "True"
-      OS_CLOUDNAME: "overcloud"
-      PYTHONWARNINGS: "ignore:Certificate has no, ignore:A true SSLContext object is not available"
-      OS_AUTH_TYPE: "password"
-      OS_AUTH_URL: "http://192.168.25.100:5000"
-      OS_IDENTITY_API_VERSION: "3"
-      OS_COMPUTE_API_VERSION: "2.latest"
-      OS_IMAGE_API_VERSION: "2"
-      OS_VOLUME_API_VERSION: "3"
-      OS_REGION_NAME: "regionOne"
 
 Create `openstackclient-admin` Secret which for a user with admin privileges (e.g. `openstackclient-admin-secret.yaml`)
 
     apiVersion: v1
+    data:
+      secure.yaml: Y2xvdWRzOgogIGRlZmF1bHQ6CiAgICBhdXRoOgogICAgICBwYXNzd29yZDogZm9vYmFyMTIzCg==
     kind: Secret
     metadata:
-      name: openstackclient-admin
+      name: openstack-config-secret
       namespace: openstack
-    data:
-      OS_USERNAME: YWRtaW4=
-      OS_PROJECT_NAME: YWRtaW4=
-      OS_PASSWORD: YWRtaW4tcGFzc3dvcmQ=
 
 Create both, ConfigMap and Secret using:
 
@@ -102,8 +97,6 @@ Create custom resource for a compute node which specifies the needed information
         novaComputeCPUDedicatedSet: "4-7"
         novaComputeCPUSharedSet: "0-3"
         sshdPort: 2022
-        commonConfigMap: common-config
-        ospSecrets: osp-secrets
       network:
         nic: "enp2s0"
         bridgeMappings: ""

--- a/api/v1alpha1/computenodeopenstack_types.go
+++ b/api/v1alpha1/computenodeopenstack_types.go
@@ -52,6 +52,8 @@ type ComputeNodeOpenStackSpec struct {
 	Network NeutronNetwork `json:"network,omitempty"`
 	// Manage selinux - Defaults to false
 	SelinuxDisabled bool `json:"selinuxDisabled,omitempty"`
+	// Cell the computes are assigned to, default cell1
+	Cell string `json:"cell,omitempty"`
 	// service account used to create pods
 	ServiceAccount string `json:"serviceAccount"`
 }
@@ -81,10 +83,14 @@ type NovaCompute struct {
 	NovaComputeCPUSharedSet string `json:"novaComputeCPUSharedSet,omitempty"`
 	// sshd migration port
 	SshdPort int32 `json:"sshdPort,omitempty"`
-	// Nova configMap containing the common config
-	CommonConfigMap string `json:"commonConfigMap,omitempty"`
-	// Nova secret containing the needed passwords
-	OspSecrets string `json:"ospSecrets,omitempty"`
+	// Nova secret containing the needed password, default "nova-secret"
+	NovaSecret string `json:"novaSecrets,omitempty"`
+	// Neutron secret containing the needed password, default "neutron-secret"
+	NeutronSecret string `json:"neutronSecrets,omitempty"`
+	// Placement secret containing the needed password, default "placement-secret"
+	PlacementSecret string `json:"placementSecrets,omitempty"`
+	// TransportURL secret containing the needed password, default nova-<CELL>-transport-url
+	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 }
 
 // NeutronNetwork defines neutron configuration parameters

--- a/bindata/nova/001-virtlogd.yaml
+++ b/bindata/nova/001-virtlogd.yaml
@@ -6,4 +6,3 @@ metadata:
 spec:
   novaLibvirtImage: quay.io/openstack-k8s-operators/nova-libvirt:latest
   roleName: {{ .WorkerOspRole }}
-  serviceAccount: nova

--- a/bindata/nova/002-libvirtd.yaml
+++ b/bindata/nova/002-libvirtd.yaml
@@ -6,4 +6,3 @@ metadata:
 spec:
   novaLibvirtImage: quay.io/openstack-k8s-operators/nova-libvirt:latest
   roleName: {{ .WorkerOspRole }}
-  serviceAccount: nova

--- a/bindata/nova/003-iscsid.yaml
+++ b/bindata/nova/003-iscsid.yaml
@@ -6,4 +6,3 @@ metadata:
 spec:
   iscsidImage: docker.io/tripleotrain/rhel-binary-iscsid:current-tripleo
   roleName: {{ .WorkerOspRole }}
-  serviceAccount: nova

--- a/bindata/nova/004-migration-target.yaml
+++ b/bindata/nova/004-migration-target.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nova-migration-target-{{ .WorkerOspRole }}
   namespace: openstack
 spec:
-  commonConfigMap: {{ .CommonConfigMap }}
-  novaComputeImage: docker.io/tripleotrain/rhel-binary-nova-compute:current-tripleo
+  novaComputeImage: docker.io/tripleomaster/centos-binary-nova-compute:current-tripleo
   roleName: {{ .WorkerOspRole }}
-  serviceAccount: nova
   sshdPort: {{ .SshdPort }}

--- a/bindata/nova/005-compute.yaml
+++ b/bindata/nova/005-compute.yaml
@@ -4,10 +4,11 @@ metadata:
   name: nova-compute-{{ .WorkerOspRole }}
   namespace: openstack
 spec:
-  commonConfigMap: {{ .CommonConfigMap }}
-  ospSecrets: {{ .OspSecrets }}
+  novaSecret: {{ .NovaSecret }}
+  neutronSecret: {{ .NeutronSecret }}
+  placementSecret: {{ .PlacementSecret }}
+  transportURLSecret: {{ .TransportURLSecret }}
   novaComputeCpuDedicatedSet: {{ .NovaComputeCPUDedicatedSet }}
   novaComputeCpuSharedSet: {{ .NovaComputeCPUSharedSet }}
-  novaComputeImage: docker.io/tripleotrain/rhel-binary-nova-compute:current-tripleo
+  novaComputeImage: docker.io/tripleomaster/centos-binary-nova-compute:current-tripleo
   roleName: {{ .WorkerOspRole }}
-  serviceAccount: nova

--- a/config/crd/bases/compute-node.openstack.org_computenodeopenstacks.yaml
+++ b/config/crd/bases/compute-node.openstack.org_computenodeopenstacks.yaml
@@ -40,14 +40,18 @@ spec:
             baseWorkerMachineSetName:
               description: Base Worker MachineSet Name
               type: string
+            cell:
+              description: Cell the computes are assigned to, default cell1
+              type: string
             clusterName:
               description: Cluster name
               type: string
             compute:
               description: Compute/Nova configuration
               properties:
-                commonConfigMap:
-                  description: Nova configMap containing the common config
+                neutronSecrets:
+                  description: Neutron secret containing the needed password, default
+                    "neutron-secret"
                   type: string
                 novaComputeCPUDedicatedSet:
                   description: CPU Dedicated Set (pinning)
@@ -55,13 +59,22 @@ spec:
                 novaComputeCPUSharedSet:
                   description: CPU Shared Set
                   type: string
-                ospSecrets:
-                  description: Nova secret containing the needed passwords
+                novaSecrets:
+                  description: Nova secret containing the needed password, default
+                    "nova-secret"
+                  type: string
+                placementSecrets:
+                  description: Placement secret containing the needed password, default
+                    "placement-secret"
                   type: string
                 sshdPort:
                   description: sshd migration port
                   format: int32
                   type: integer
+                transportURLSecret:
+                  description: TransportURL secret containing the needed password,
+                    default nova-<CELL>-transport-url
+                  type: string
               type: object
             corePinning:
               description: Cores Pinning

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -92,8 +92,8 @@ rules:
   - update
   - watch
 - apiGroups:
-  - machineconfiguration.openshift.io
   - machine.openshift.io
+  - machineconfiguration.openshift.io
   resources:
   - '*'
   verbs:


### PR DESCRIPTION
- no requirement for common-config
- secrets for the different service, which are optional and default
  to what is used in openstack-cluster-operator
- switch to openstack client CM/secret which is created by the
  openstack-cluster-operator